### PR TITLE
Actually ask for Authentication when the user is not authenticated.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,7 @@ export function basicAuth(userOptions: Partial<BasicAuthOptions> = {}) {
     .state('basicAuthRealm', null as string | null)
     .state('basicAuthUser', null as string | null)
     .error({ BASIC_AUTH_ERROR: BasicAuthError })
-    .onError(({ code, error }) => {
+    .onError({ as: "global" }, ({ code, error }) => {
       if (code === 'BASIC_AUTH_ERROR' && error.realm === options.realm) {
         return new Response(options.unauthorizedMessage, {
           status: options.unauthorizedStatus,


### PR DESCRIPTION
Hey there 👋
Thank you for this plugin :)

I had a bug with latest Elysia, where the page wouldn't ask for authentication, and just display the json error `{ 'name': 'Invalid header' }`

it seems that the `onError` handler needs to be at a "global" scope to work.

With this patch, the authentication is correctly asked when accessing the page.
Thanks!

