### PR TITLE
fix: detection of CORS preflight requests for `skipCorsPreflight` option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ function isCORSPreflightRequest(request: Request) {
   return (
     request.method === 'OPTIONS' &&
     request.headers.has('Origin') &&
-    request.headers.has('Cross-Origin-Request-Method')
+    request.headers.has('Access-Control-Request-Method')
   )
 }
 


### PR DESCRIPTION
It seems like this checker was checking the incorrect request header. `Cross-Origin-Request-Method` doesn't seem to be included in CORS preflight requests, so I changed it to [Access-Control-Request-Method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method) and the `skipCorsPreflight` works now.

![image](https://github.com/user-attachments/assets/cf4e93f9-3c62-44ff-bef0-3decdebaed09)


```diff
/**
 * Checks if the request is a CORS preflight request
 */
function isCORSPreflightRequest(request: Request) {
  return (
    request.method === "OPTIONS" &&
    request.headers.has("Origin") &&
-    request.headers.has("Cross-Origin-Request-Method")
+    request.headers.has("Access-Control-Request-Method")
  )
}
```

